### PR TITLE
Добавляет алгорим поиска фактор множества по множеcтву вершин

### DIFF
--- a/src/DirectedAcyclicGraph.test.ts
+++ b/src/DirectedAcyclicGraph.test.ts
@@ -34,7 +34,6 @@ describe(' Directed Acyclic Graph', () => {
       /**
        * Created DAG should has all and only edges specified by mock.
        */
-      console.log([...dag.edges].length, [...mock.edges].length);
       expect(
         areMultisetsEqual([...dag.edges], [...mock.edges], {
           equal: edgesEqual,

--- a/src/algo/getEquivalentNodes.test.ts
+++ b/src/algo/getEquivalentNodes.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest';
+import {
+  AntichainMock,
+  ChainMock,
+  CrownMock,
+  LayeredMock,
+} from '../test/mocks';
+import {
+  getEquivalentNodesByParents,
+  getEquivalentNodesByChildren,
+  getEquivalentNodes,
+} from './getEquivalentNodes';
+import { ReadonlyDirectedAcyclicGraph } from '../models';
+import { areSetsEqual } from '../test';
+
+function isEqualByParent<Node>(
+  a: Node,
+  b: Node,
+  dag: ReadonlyDirectedAcyclicGraph<Node>,
+  subset: Set<Node>,
+): boolean {
+  return areSetsEqual(
+    new Set([...dag.parentsOf(a)].filter((node) => subset.has(node))),
+    new Set([...dag.parentsOf(b)].filter((node) => subset.has(node))),
+  );
+}
+
+function isEqualByChildren<Node>(
+  a: Node,
+  b: Node,
+  dag: ReadonlyDirectedAcyclicGraph<Node>,
+  subset: Set<Node>,
+): boolean {
+  return areSetsEqual(
+    new Set([...dag.childrenOf(a)].filter((node) => subset.has(node))),
+    new Set([...dag.childrenOf(b)].filter((node) => subset.has(node))),
+  );
+}
+
+describe('Quotient Set', () => {
+  const testCases = [
+    { title: 'antichain', mock: new AntichainMock(10) },
+    { title: 'chain', mock: new ChainMock(10) },
+    { title: 'crown', mock: new CrownMock(5) },
+    { title: 'layered', mock: new LayeredMock([2, 2, 2, 2, 2]) },
+  ];
+
+  describe('should correctly get quotient set of any node subset', () => {
+    describe.each([
+      {
+        by: 'parent',
+        isEqual: isEqualByParent,
+        getProjection: getEquivalentNodesByParents,
+      },
+      {
+        by: 'children',
+        isEqual: isEqualByChildren,
+        getProjection: getEquivalentNodesByChildren,
+      },
+      {
+        by: '{parent, children}',
+        isEqual: (...args) =>
+          isEqualByParent(...args) && isEqualByChildren(...args),
+        getProjection: getEquivalentNodes,
+      },
+    ])('by $by', ({ getProjection, isEqual }) => {
+      test.each(testCases)('$title', ({ mock }) => {
+        const nodes = [...mock];
+        for (let size = 0; size < 2 ** nodes.length - 1; ++size) {
+          const subset = new Set(
+            nodes.filter((_, index) => (2 ** index) & size),
+          );
+          const projection = getProjection(mock, subset);
+
+          for (const node of subset) {
+            /**
+             * All and only nodes in subset should be classified.
+             */
+            expect(
+              subset.has(node) === (projection.has(node) !== undefined),
+            ).toBeTruthy();
+          }
+
+          for (const a of subset) {
+            for (const b of subset) {
+              /**
+               * Equivalent nodes must be in the same equivalence class.
+               */
+              expect(
+                isEqual(a, b, mock, subset) ===
+                  (projection.get(a) === projection.get(b)),
+              ).toBeTruthy();
+            }
+          }
+        }
+      });
+    });
+  });
+});

--- a/src/algo/getEquivalentNodes.ts
+++ b/src/algo/getEquivalentNodes.ts
@@ -1,0 +1,104 @@
+import { ReadonlyDirectedAcyclicGraph } from '../models';
+import { ForceMap, Trie } from '../utils';
+
+/**
+ * Split `nodes` into equivalence classes by equivalence relation
+ * `a ~ b <=> parentsOf(a) = parentsOf(b)`
+ *
+ * @param dag - Souce graph.
+ * @param nodes - Subset of nodes to be classified.
+ *
+ * @returns Canonical projection of quotient set.
+ *
+ * @remarks
+ * Time complexity (V8): `O(n^2 + e)` where
+ * * `n` - number of nodes in the DAG
+ * * `e` - number of edges in the DAG.
+ */
+export function getEquivalentNodesByParents<Node>(
+  dag: ReadonlyDirectedAcyclicGraph<Node>,
+  nodes: Set<Node>,
+) {
+  const projection = new Map<Node, Set<Node>>();
+  const sortedParents = new ForceMap<Node, Node[]>(() => []);
+  const equivalenceClass = new Trie<Node, Set<Node>>();
+
+  for (const node of dag) {
+    if (!nodes.has(node)) continue;
+
+    const parents = sortedParents.forceGet(node);
+    const cls =
+      equivalenceClass.get(parents) ??
+      equivalenceClass.set(parents, new Set<Node>());
+    cls.add(node);
+    projection.set(node, cls);
+
+    for (const child of dag.childrenOf(node)) {
+      if (!nodes.has(child)) continue;
+      sortedParents.forceGet(child).push(node);
+    }
+  }
+
+  return projection;
+}
+
+/**
+ * Split `nodes` into equivalence classes by equivalence relation
+ * `a ~ b <=> childrenOf(a) = childrenOf(b)`
+ *
+ * @param dag - Souce graph.
+ * @param nodes - Subset of nodes to be classified.
+ *
+ * @returns Canonical projection of quotient set.
+ *
+ * @remarks
+ * Time complexity (V8): `O(n^2 + e)` where
+ * * `n` - number of nodes in the DAG
+ * * `e` - number of edges in the DAG.
+ */
+export function getEquivalentNodesByChildren<Node>(
+  dag: ReadonlyDirectedAcyclicGraph<Node>,
+  nodes: Set<Node>,
+) {
+  return getEquivalentNodesByParents(dag.reversed(), nodes);
+}
+
+/**
+ * Split `nodes` into equivalence classes by equivalence relation
+ * `a ~ b <=> {parentsOf(a), childrenOf(a)} = {parentsOf(b), childrenOf(b)}`
+ *
+ * @param dag - Souce graph.
+ * @param nodes - Subset of nodes to be classified.
+ *
+ * @returns Canonical projection of quotient set.
+ *
+ * @remarks
+ * Time complexity (V8): `O(n^2 + e)` where
+ * * `n` - number of nodes in the DAG
+ * * `e` - number of edges in the DAG.
+ */
+export function getEquivalentNodes<Node>(
+  dag: ReadonlyDirectedAcyclicGraph<Node>,
+  nodes: Set<Node>,
+) {
+  const projection = new Map<Node, Set<Node>>();
+
+  const pairMap = new ForceMap<Set<Node>, ForceMap<Set<Node>, Set<Node>>>(
+    () => new ForceMap<Set<Node>, Set<Node>>(() => new Set<Node>()),
+  );
+
+  const byParents = getEquivalentNodesByParents(dag, nodes);
+  const byChildren = getEquivalentNodesByChildren(dag, nodes);
+
+  for (const node of nodes) {
+    projection.set(
+      node,
+      pairMap
+        .forceGet(byParents.get(node)!)
+        .forceGet(byChildren.get(node)!)
+        .add(node),
+    );
+  }
+
+  return projection;
+}

--- a/src/algo/index.ts
+++ b/src/algo/index.ts
@@ -1,3 +1,4 @@
 export * from './DepthFirstIterator';
 export * from './BreadthFirstIterator';
 export * from './planarizeDirectedMultipartite';
+export * from './getEquivalentNodes';

--- a/src/test/mocks/DirectedAcyclicGraphMock.ts
+++ b/src/test/mocks/DirectedAcyclicGraphMock.ts
@@ -105,7 +105,7 @@ export class DirectedAcyclicGraphMock<Node>
       descendants: this._ancestors,
       ancestors: this._descendants,
       size: this._size,
-      sorted: this._sorted,
+      sorted: [...this._sorted].reverse(),
     });
   }
 

--- a/src/test/mocks/LayeredMock.ts
+++ b/src/test/mocks/LayeredMock.ts
@@ -57,7 +57,7 @@ export class LayeredMock extends DirectedAcyclicGraphMock<MockNode> {
     );
 
     const descendants = getDescendants(layers);
-    const ancestors = getDescendants(layers.reverse());
+    const ancestors = getDescendants([...layers].reverse());
 
     const nodes = layers.flat();
     super({

--- a/src/utils/Trie.ts
+++ b/src/utils/Trie.ts
@@ -1,0 +1,34 @@
+import { ForceMap } from './ForceMap';
+
+class TrieNode<K, V> {
+  next = new ForceMap<K, TrieNode<K, V>>(() => new TrieNode());
+  value?: V;
+}
+
+export class Trie<K, V> {
+  private root: TrieNode<K, V>;
+
+  constructor() {
+    this.root = new TrieNode();
+  }
+
+  public get(key: Iterable<K>): V | undefined {
+    let node: TrieNode<K, V> | undefined = this.root;
+    for (const sym of key) {
+      if (node === undefined) {
+        return undefined;
+      }
+      node = node.next.get(sym);
+    }
+    return node?.value;
+  }
+
+  public set(key: Iterable<K>, value: V): V {
+    let node: TrieNode<K, V> = this.root;
+    for (const sym of key) {
+      node = node.next.forceGet(sym);
+    }
+    node.value = value;
+    return value;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './ForceMap';
 export * from './ProxyReadonlySet';
+export * from './Trie';


### PR DESCRIPTION
1. `getEquivalentNodes` - проекция фактор множества по родителям и детям (неупорядоченная пара)
2. `getEquivalentNodesByParents` - проекция фактор множеcтва по родителям
3. `getEquivalentNodesByChildren` - проекция фактор множества по детям
4. Тесты новых алгосов и исправление моков
Closes #14 