### PR TITLE
Базовые бенчмарки

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "stylelint-check": "stylelint --allow-empty-input 'demo/**/*.css'",
     "prettier-check": "prettier --check src",
     "unit": "vitest",
+    "bench": "vitest bench",
     "build": "vite build"
   },
   "author": "",
@@ -43,6 +44,7 @@
     "react-router-dom": "^6.28.0",
     "stylelint": "^16.10.0",
     "stylelint-config-standard": "^36.0.1",
+    "tinybench": "^4.0.1",
     "typescript": "^5.6.3",
     "typescript-eslint": "^7.18.0",
     "vite": "^5.4.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 4.3.4(vite@5.4.11)
       '@xyflow/react':
         specifier: ^12.3.5
-        version: 12.3.5(@types/react@18.3.14)(react-dom@18.3.1)(react@18.3.1)
+        version: 12.3.5(@types/react@18.3.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -31,7 +31,7 @@ importers:
         version: 9.1.0(eslint@8.57.1)
       eslint-plugin-prettier:
         specifier: ^5.2.1
-        version: 5.2.1(eslint-config-prettier@9.1.0)(eslint@8.57.1)(prettier@3.4.2)
+        version: 5.2.1(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.4.2)
       prettier:
         specifier: ^3.3.3
         version: 3.4.2
@@ -43,13 +43,16 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-router-dom:
         specifier: ^6.28.0
-        version: 6.28.0(react-dom@18.3.1)(react@18.3.1)
+        version: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       stylelint:
         specifier: ^16.10.0
         version: 16.11.0(typescript@5.7.2)
       stylelint-config-standard:
         specifier: ^36.0.1
-        version: 36.0.1(stylelint@16.11.0)
+        version: 36.0.1(stylelint@16.11.0(typescript@5.7.2))
+      tinybench:
+        specifier: ^4.0.1
+        version: 4.0.1
       typescript:
         specifier: ^5.6.3
         version: 5.7.2
@@ -61,10 +64,10 @@ importers:
         version: 5.4.11
       vite-plugin-dts:
         specifier: ^3.9.1
-        version: 3.9.1(typescript@5.7.2)(vite@5.4.11)
+        version: 3.9.1(rollup@4.28.1)(typescript@5.7.2)(vite@5.4.11)
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(typescript@5.7.2)(vite@5.4.11)
+        version: 4.3.0(rollup@4.28.1)(typescript@5.7.2)(vite@5.4.11)
       vitest:
         specifier: ^1.6.0
         version: 1.6.0
@@ -1795,6 +1798,10 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinybench@4.0.1:
+    resolution: {integrity: sha512-Nb1srn7dvzkVx0J5h1vq8f48e3TIcbrS7e/UfAI/cDSef/n8yLh4zsAEsFkfpw6auTY+ZaspEvam/xs8nMnotQ==}
+    engines: {node: '>=18.0.0'}
+
   tinypool@0.8.4:
     resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
     engines: {node: '>=14.0.0'}
@@ -2143,7 +2150,7 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.3': {}
 
-  '@csstools/media-query-list-parser@4.0.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)':
+  '@csstools/media-query-list-parser@4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
@@ -2330,11 +2337,13 @@ snapshots:
 
   '@remix-run/router@1.21.0': {}
 
-  '@rollup/pluginutils@5.1.3':
+  '@rollup/pluginutils@5.1.3(rollup@4.28.1)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.28.1
 
   '@rollup/rollup-android-arm-eabi@4.28.1':
     optional: true
@@ -2483,7 +2492,7 @@ snapshots:
       '@babel/types': 7.26.3
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0)':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.7.2))':
     dependencies:
       '@babel/core': 7.26.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.26.0)
@@ -2550,7 +2559,7 @@ snapshots:
       '@types/prop-types': 15.7.14
       csstype: 3.1.3
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.7.2)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.7.2)
@@ -2563,6 +2572,7 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       ts-api-utils: 1.4.3(typescript@5.7.2)
+    optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
@@ -2575,6 +2585,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.0
       eslint: 8.57.1
+    optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
@@ -2591,6 +2602,7 @@ snapshots:
       debug: 4.4.0
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@5.7.2)
+    optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
@@ -2607,6 +2619,7 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.6.3
       ts-api-utils: 1.4.3(typescript@5.7.2)
+    optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
@@ -2705,12 +2718,13 @@ snapshots:
       minimatch: 9.0.5
       muggle-string: 0.3.1
       path-browserify: 1.0.1
-      typescript: 5.7.2
       vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 5.7.2
 
   '@vue/shared@3.5.13': {}
 
-  '@xyflow/react@12.3.5(@types/react@18.3.14)(react-dom@18.3.1)(react@18.3.1)':
+  '@xyflow/react@12.3.5(@types/react@18.3.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@xyflow/system': 0.0.46
       classcat: 5.0.5
@@ -2855,6 +2869,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.7.2
 
   cosmiconfig@9.0.0(typescript@5.7.2):
@@ -2863,6 +2878,7 @@ snapshots:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
+    optionalDependencies:
       typescript: 5.7.2
 
   cross-spawn@7.0.6:
@@ -2991,13 +3007,14 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-prettier@5.2.1(eslint-config-prettier@9.1.0)(eslint@8.57.1)(prettier@3.4.2):
+  eslint-plugin-prettier@5.2.1(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.4.2):
     dependencies:
       eslint: 8.57.1
-      eslint-config-prettier: 9.1.0(eslint@8.57.1)
       prettier: 3.4.2
       prettier-linter-helpers: 1.0.0
       synckit: 0.9.2
+    optionalDependencies:
+      eslint-config-prettier: 9.1.0(eslint@8.57.1)
 
   eslint-scope@7.2.2:
     dependencies:
@@ -3526,7 +3543,7 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-router-dom@6.28.0(react-dom@18.3.1)(react@18.3.1):
+  react-router-dom@6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@remix-run/router': 1.21.0
       react: 18.3.1
@@ -3659,20 +3676,20 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stylelint-config-recommended@14.0.1(stylelint@16.11.0):
+  stylelint-config-recommended@14.0.1(stylelint@16.11.0(typescript@5.7.2)):
     dependencies:
       stylelint: 16.11.0(typescript@5.7.2)
 
-  stylelint-config-standard@36.0.1(stylelint@16.11.0):
+  stylelint-config-standard@36.0.1(stylelint@16.11.0(typescript@5.7.2)):
     dependencies:
       stylelint: 16.11.0(typescript@5.7.2)
-      stylelint-config-recommended: 14.0.1(stylelint@16.11.0)
+      stylelint-config-recommended: 14.0.1(stylelint@16.11.0(typescript@5.7.2))
 
   stylelint@16.11.0(typescript@5.7.2):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
       '@dual-bundle/import-meta-resolve': 4.1.0
       balanced-match: 2.0.0
@@ -3748,6 +3765,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinybench@4.0.1: {}
+
   tinypool@0.8.4: {}
 
   tinyspy@2.2.1: {}
@@ -3772,10 +3791,11 @@ snapshots:
 
   typescript-eslint@7.18.0(eslint@8.57.1)(typescript@5.7.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.7.2)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1)(typescript@5.7.2)
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.7.2)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
+    optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
@@ -3824,27 +3844,28 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@3.9.1(typescript@5.7.2)(vite@5.4.11):
+  vite-plugin-dts@3.9.1(rollup@4.28.1)(typescript@5.7.2)(vite@5.4.11):
     dependencies:
       '@microsoft/api-extractor': 7.43.0
-      '@rollup/pluginutils': 5.1.3
+      '@rollup/pluginutils': 5.1.3(rollup@4.28.1)
       '@vue/language-core': 1.8.27(typescript@5.7.2)
       debug: 4.4.0
       kolorist: 1.8.0
       magic-string: 0.30.14
       typescript: 5.7.2
-      vite: 5.4.11
       vue-tsc: 1.8.27(typescript@5.7.2)
+    optionalDependencies:
+      vite: 5.4.11
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-svgr@4.3.0(typescript@5.7.2)(vite@5.4.11):
+  vite-plugin-svgr@4.3.0(rollup@4.28.1)(typescript@5.7.2)(vite@5.4.11):
     dependencies:
-      '@rollup/pluginutils': 5.1.3
+      '@rollup/pluginutils': 5.1.3(rollup@4.28.1)
       '@svgr/core': 8.1.0(typescript@5.7.2)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.7.2))
       vite: 5.4.11
     transitivePeerDependencies:
       - rollup
@@ -3943,6 +3964,7 @@ snapshots:
 
   zustand@4.5.5(@types/react@18.3.14)(react@18.3.1):
     dependencies:
+      use-sync-external-store: 1.2.2(react@18.3.1)
+    optionalDependencies:
       '@types/react': 18.3.14
       react: 18.3.1
-      use-sync-external-store: 1.2.2(react@18.3.1)

--- a/src/DirectedAcyclicGraph.bench.ts
+++ b/src/DirectedAcyclicGraph.bench.ts
@@ -1,0 +1,216 @@
+import { Bench } from 'tinybench';
+import { bench, describe } from 'vitest';
+
+import { AbstractDirectedAcyclicGraph } from './models';
+import { EdgeAdditionStrategy } from './DirectedAcyclicGraph';
+
+import { Chain, getMockNode, Layered, MockNode } from 'src/test';
+
+const sizes = [
+  100, 300, 500, 700, 1_000, 3_000, 5_000, 7_000, 10_000, 15_000, 25_000,
+];
+const mutationSizes = [100, 300, 500, 700, 1_000, 3_000, 5_000];
+
+describe('has node', () => {
+  sizes
+    .map((size) => {
+      const dag = new Chain(size);
+      return { dag, node: [...dag.nodes][Math.floor(Math.random() * size)] };
+    })
+    .forEach(({ dag, node }) => {
+      bench(
+        `${dag.size.nodes} nodes; ${dag.size.edges} edges`,
+        () => {
+          dag.has(node);
+        },
+        { time: 0, iterations: 10000 },
+      );
+    });
+});
+
+describe('has edge', () => {
+  sizes
+    .map((size) => {
+      const dag = new Chain(size);
+      const nodes = [...dag.nodes];
+      return {
+        dag,
+        tail: nodes[Math.floor(Math.random() * size)],
+        head: nodes[Math.floor(Math.random() * size)],
+      };
+    })
+    .forEach(({ dag, tail, head }) => {
+      bench(
+        `${dag.size.nodes} nodes; ${dag.size.edges} edges`,
+        () => {
+          dag.hasEdge(tail, head);
+        },
+        { time: 0, iterations: 10000 },
+      );
+    });
+});
+
+describe('parents of node', () => {
+  sizes
+    .map((size) => {
+      const dag = new Layered([size - 1, 1]);
+      return { dag, node: [...dag.nodes][0] };
+    })
+    .forEach(({ dag, node }) => {
+      bench(
+        `${dag.size.nodes} nodes; ${dag.size.edges} edges`,
+        () => {
+          dag.parentsOf(node);
+        },
+        { time: 0, iterations: 10000 },
+      );
+    });
+});
+
+describe('children of node', () => {
+  sizes
+    .map((size) => {
+      const dag = new Layered([1, size - 1]);
+      const nodes = [...dag.nodes];
+      return { dag, node: nodes[nodes.length - 1] };
+    })
+    .forEach(({ dag, node }) => {
+      bench(
+        `${dag.size.nodes} nodes; ${dag.size.edges} edges`,
+        () => {
+          dag.childrenOf(node);
+        },
+        { time: 0, iterations: 10000 },
+      );
+    });
+});
+
+// TODO: rewrite mutation benchmarks after closing vitest issue
+// https://github.com/vitest-dev/vitest/issues/7599
+
+await (async () => {
+  const bench = new Bench({
+    warmupTime: 0,
+    time: 0,
+    iterations: 1000,
+  });
+
+  let dag: AbstractDirectedAcyclicGraph<MockNode>;
+  mutationSizes.forEach((size) => {
+    bench.add(
+      `add node, ${size} nodes + ${size - 1} edges`,
+      () => {
+        dag!.add(getMockNode());
+      },
+      {
+        beforeEach: () => {
+          dag = new Chain(size);
+        },
+      },
+    );
+  });
+
+  await bench.run();
+  console.table(bench.table());
+})();
+
+await (async () => {
+  const bench = new Bench({
+    warmupTime: 0,
+    time: 0,
+    iterations: 1000,
+  });
+
+  let dag: AbstractDirectedAcyclicGraph<MockNode>;
+  let node: MockNode;
+  mutationSizes.forEach((size) => {
+    bench.add(
+      `delete node, parents + children = ${size}`,
+      () => {
+        dag!.delete(node!);
+      },
+      {
+        beforeEach: () => {
+          dag = new Layered([size / 2, 1, size / 2]);
+          for (const n of dag.nodes) {
+            if (dag.childrenOf(n).size === size / 2) {
+              node = n;
+              break;
+            }
+          }
+        },
+      },
+    );
+  });
+
+  await bench.run();
+  console.table(bench.table());
+})();
+
+await (async () => {
+  for (const strategy of [
+    EdgeAdditionStrategy.SAFE,
+    EdgeAdditionStrategy.UNSAFE,
+  ]) {
+    const bench = new Bench({
+      warmupTime: 0,
+      time: 0,
+      iterations: 1000,
+    });
+
+    let dag: AbstractDirectedAcyclicGraph<MockNode>;
+    let tail: MockNode;
+    let head: MockNode;
+    mutationSizes.forEach((size) => {
+      bench.add(
+        `connect nodes (${strategy}), ${size} nodes + ${size - 1} edges in children subtree`,
+        () => {
+          dag!.connect(tail!, head!);
+        },
+        {
+          beforeEach: () => {
+            dag = new Layered([1, size - 1], {
+              edgeAdditionStrategy: strategy,
+            });
+            dag.add((tail = getMockNode()));
+            head = dag.nodes.next().value!;
+          },
+        },
+      );
+    });
+
+    await bench.run();
+    console.table(bench.table());
+  }
+})();
+
+await (async () => {
+  const bench = new Bench({
+    warmupTime: 0,
+    time: 0,
+    iterations: 1000,
+  });
+
+  let dag: AbstractDirectedAcyclicGraph<MockNode>;
+  let tail: MockNode;
+  let head: MockNode;
+  mutationSizes.forEach((size) => {
+    bench.add(
+      `disconnect nodes, ${size} nodes + ${size - 1} edges`,
+      () => {
+        dag!.disconnect(tail!, head!);
+      },
+      {
+        beforeEach: () => {
+          dag = new Chain(size);
+          const nodes = [...dag.nodes];
+          tail = nodes[Math.ceil(Math.random() * nodes.length)];
+          head = nodes[Math.ceil(Math.random() * nodes.length)];
+        },
+      },
+    );
+  });
+
+  await bench.run();
+  console.table(bench.table());
+})();

--- a/src/algo/BreadthFirstIterator.bench.ts
+++ b/src/algo/BreadthFirstIterator.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe } from 'vitest';
+
+import { AbstractDirectedAcyclicGraph } from 'src/models';
+import { Layered, MockNode } from 'src/test';
+
+import BreadthFirstIterator from './BreadthFirstIterator';
+
+const sizes = [
+  100, 300, 500, 700, 1_000, 3_000, 5_000, 7_000, 10_000, 15_000, 25_000,
+];
+
+const cases: { n: number; e: number }[] = [];
+for (const n of sizes) {
+  for (const e of sizes) {
+    if (e < n || (n * (n + 1)) / 2 < e) continue;
+    cases.push({ n, e });
+  }
+}
+
+describe('breadth first iterator', () => {
+  let dag: AbstractDirectedAcyclicGraph<MockNode>;
+  let root: MockNode;
+  cases.forEach(({ n, e }) => {
+    bench(
+      `${n} nodes; ${e} edges`,
+      () => {
+        [...new BreadthFirstIterator(dag!, root!)];
+      },
+      {
+        setup: () => {
+          dag = new Layered([1, n - 1]);
+
+          const nodes = [...dag.nodes];
+          root = nodes[0];
+
+          for (let tailIndex = 1; tailIndex < nodes.length; ++tailIndex) {
+            for (
+              let headIndex = tailIndex + 1;
+              headIndex < nodes.length;
+              ++headIndex
+            ) {
+              if (dag.size.edges >= e) return;
+              dag.connect(nodes[tailIndex], nodes[headIndex]);
+            }
+          }
+        },
+      },
+    );
+  });
+});

--- a/src/algo/DepthFirstIterator.bench.ts
+++ b/src/algo/DepthFirstIterator.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe } from 'vitest';
+
+import { AbstractDirectedAcyclicGraph } from 'src/models';
+import { Chain, MockNode } from 'src/test';
+
+import { DepthFirstIterator } from './DepthFirstIterator';
+
+const sizes = [
+  100, 300, 500, 700, 1_000, 3_000, 5_000, 7_000, 10_000, 15_000, 25_000,
+];
+
+const cases: { n: number; e: number }[] = [];
+for (const n of sizes) {
+  for (const e of sizes) {
+    if (e < n || (n * (n + 1)) / 2 < e) continue;
+    cases.push({ n, e });
+  }
+}
+
+describe('depth first iterator', () => {
+  let dag: AbstractDirectedAcyclicGraph<MockNode>;
+  let root: MockNode;
+  cases.forEach(({ n, e }) => {
+    bench(
+      `${n} nodes; ${e} edges`,
+      () => {
+        [...new DepthFirstIterator(dag!, root!)];
+      },
+      {
+        setup: () => {
+          dag = new Chain(n);
+
+          const nodes = [...dag.nodes];
+          root = nodes[0];
+
+          for (let tailIndex = 1; tailIndex < nodes.length; ++tailIndex) {
+            for (
+              let headIndex = tailIndex + 1;
+              headIndex < nodes.length;
+              ++headIndex
+            ) {
+              if (dag.size.edges >= e) return;
+              dag.connect(nodes[tailIndex], nodes[headIndex]);
+            }
+          }
+        },
+      },
+    );
+  });
+});

--- a/src/algo/getEquivalentNodes.bench.ts
+++ b/src/algo/getEquivalentNodes.bench.ts
@@ -1,0 +1,26 @@
+import { bench, describe } from 'vitest';
+
+import { AbstractDirectedAcyclicGraph } from 'src/models';
+import { Layered, MockNode } from 'src/test';
+
+import { getEquivalentNodes } from '..';
+
+const sizes = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1_000];
+
+describe('get equivalent nodes', () => {
+  let dag: AbstractDirectedAcyclicGraph<MockNode>;
+  sizes.forEach((n) => {
+    bench(
+      `${n} nodes; ${(n / 2) * (n / 2)} edges`,
+      () => {
+        getEquivalentNodes(dag, new Set(dag.nodes));
+      },
+      {
+        iterations: 100,
+        setup: () => {
+          dag = new Layered([n / 2, n / 2]);
+        },
+      },
+    );
+  });
+});

--- a/src/algo/planarizeDirectedMultipartite.bench.ts
+++ b/src/algo/planarizeDirectedMultipartite.bench.ts
@@ -1,0 +1,35 @@
+import { bench, describe } from 'vitest';
+
+import {
+  AbstractDirectedAcyclicGraph,
+  AbstractDirectedMultipartite,
+} from 'src/models';
+import { Layered, MockNode } from 'src/test';
+
+import { OrderedMultipartite, planarizeDirectedMultipartite } from '..';
+
+const sizes = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1_000];
+
+describe('planarize directed multipartite', () => {
+  let dag: AbstractDirectedAcyclicGraph<MockNode>;
+  let multipartite: AbstractDirectedMultipartite<MockNode>;
+  sizes.forEach((n) => {
+    bench(
+      `${n} nodes; ${(n / 2) * (n / 2)} edges`,
+      () => {
+        planarizeDirectedMultipartite(multipartite, dag);
+      },
+      {
+        iterations: 100,
+        setup: () => {
+          dag = new Layered([n / 2, n / 2]);
+
+          multipartite = new OrderedMultipartite<MockNode>();
+          [...dag.nodes].forEach((node, i) =>
+            multipartite.set(node, i < n / 2 ? 0 : 1),
+          );
+        },
+      },
+    );
+  });
+});

--- a/src/test/mocks/AntichainMock.ts
+++ b/src/test/mocks/AntichainMock.ts
@@ -1,5 +1,9 @@
+import {
+  DirectedAcyclicGraph,
+  DirectedAcyclicGraphOptions,
+} from 'src/DirectedAcyclicGraph';
 import { DirectedAcyclicGraphMock } from './DirectedAcyclicGraphMock';
-import { getMockNodes } from '../utils';
+import { getMockNode, getMockNodes } from '../utils';
 import { MockNode } from '..';
 
 /**
@@ -26,5 +30,15 @@ export class AntichainMock extends DirectedAcyclicGraphMock<MockNode> {
       size: { nodes: size, edges: 0, depth: 0, width: size },
       sorted: nodes,
     });
+  }
+}
+
+export class Antichain extends DirectedAcyclicGraph<MockNode> {
+  constructor(size: number, options?: DirectedAcyclicGraphOptions) {
+    super(options);
+    for (let i = 1; i < size; ++i) {
+      const node = getMockNode();
+      this.add(node);
+    }
   }
 }

--- a/src/test/mocks/ChainMock.ts
+++ b/src/test/mocks/ChainMock.ts
@@ -1,7 +1,11 @@
 import { DirectedAcyclicGraphMock } from './DirectedAcyclicGraphMock';
-import { getMockNodes } from '../utils';
+import { getMockNode, getMockNodes } from '../utils';
 import { ForceMap } from '../../utils';
 import { MockNode } from '..';
+import {
+  DirectedAcyclicGraph,
+  DirectedAcyclicGraphOptions,
+} from 'src/DirectedAcyclicGraph';
 
 /**
  * Creates the chain DAG:
@@ -53,5 +57,20 @@ export class ChainMock extends DirectedAcyclicGraphMock<MockNode> {
       size: { nodes: size, edges: size - 1, depth: size - 1, width: 1 },
       sorted: nodes,
     });
+  }
+}
+
+export class Chain extends DirectedAcyclicGraph<MockNode> {
+  constructor(size: number, options?: DirectedAcyclicGraphOptions) {
+    super(options);
+
+    const root = getMockNode();
+    this.add(root);
+
+    for (let i = 1; i < size; ++i) {
+      const node = getMockNode();
+      this.add(node);
+      if (i > 0) this.connect(root, node);
+    }
   }
 }

--- a/src/test/mocks/LayeredMock.ts
+++ b/src/test/mocks/LayeredMock.ts
@@ -1,7 +1,11 @@
 import { DirectedAcyclicGraphMock } from './DirectedAcyclicGraphMock';
-import { getMockNodes } from '../utils';
+import { getMockNode, getMockNodes } from '../utils';
 import { ForceMap } from '../../utils';
 import { MockNode } from '..';
+import {
+  DirectedAcyclicGraph,
+  DirectedAcyclicGraphOptions,
+} from 'src/DirectedAcyclicGraph';
 
 function getDescendants(layers: MockNode[][]) {
   const descendants = new ForceMap<MockNode, Set<MockNode>[]>(() => [
@@ -76,5 +80,28 @@ export class LayeredMock extends DirectedAcyclicGraphMock<MockNode> {
       },
       sorted: nodes,
     });
+  }
+}
+
+export class Layered extends DirectedAcyclicGraph<MockNode> {
+  constructor(nodes: number[], options?: DirectedAcyclicGraphOptions) {
+    super(options);
+
+    let layer = [];
+    let previous = [];
+    for (const size of nodes) {
+      previous = layer;
+      layer = [];
+
+      for (let i = 0; i < size; ++i) {
+        this.add(layer[layer.push(getMockNode()) - 1]);
+      }
+
+      for (const tail of previous) {
+        for (const head of layer) {
+          this.connect(tail, head);
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Добавляет бенчмарки для
1. Получения детей/родителей, добавления/удаления вершины, добавления/удаления ребра
2. BFS, DFS
3. Алгоритма планаризации
4. Алгоритма поиска идентичных вершин

бенчмарки мутаций сейчас написаны нативно на `tinybench`, т.к. `vitest` еще не успели добавить нужный функционал (но добавят), перепишу [тут](https://github.com/graph-tools/dag-web-tools/issues/36)

Запуск:
```
pnpm run bench
```